### PR TITLE
[POC] Table row extentions

### DIFF
--- a/libs/table/src/lib/lazy-condition/ast/context.ts
+++ b/libs/table/src/lib/lazy-condition/ast/context.ts
@@ -1,0 +1,30 @@
+import {
+  LazyConditionAstDef,
+  LazyConditionNode,
+  LazyConditionNodeEvaluator,
+} from '../lazy-condition';
+
+export const LazyConditionNodeKindContext = 2;
+
+export interface LazyConditionContextNode extends LazyConditionNode {
+  kind: typeof LazyConditionNodeKindContext;
+  property: string;
+}
+
+export function createLazyConditionContext(
+  property: string,
+): LazyConditionContextNode {
+  return { kind: LazyConditionNodeKindContext, property };
+}
+
+export class LazyConditionContextEvaluator
+  implements LazyConditionNodeEvaluator<LazyConditionContextNode, boolean> {
+  evaluate(node: LazyConditionContextNode, context: unknown): boolean {
+    return (context as any)?.[node.property];
+  }
+}
+
+export class LazyConditionAstContext implements LazyConditionAstDef {
+  kind = LazyConditionNodeKindContext;
+  evaluator = new LazyConditionContextEvaluator();
+}

--- a/libs/table/src/lib/lazy-condition/ast/equals.ts
+++ b/libs/table/src/lib/lazy-condition/ast/equals.ts
@@ -1,0 +1,40 @@
+import {
+  LazyConditionAstDef,
+  LazyConditionNode,
+  LazyConditionNodeEvaluator,
+} from '../lazy-condition';
+
+export const LazyConditionNodeKindEquals = 1;
+
+export interface LazyConditionEqualsNode extends LazyConditionNode {
+  kind: typeof LazyConditionNodeKindEquals;
+  operands: LazyConditionNode[];
+}
+
+export function createLazyConditionEquals(
+  operands: LazyConditionNode[],
+): LazyConditionEqualsNode {
+  return { kind: LazyConditionNodeKindEquals, operands };
+}
+
+export class LazyConditionEqualsEvaluator
+  implements LazyConditionNodeEvaluator<LazyConditionEqualsNode, boolean> {
+  private evaluator?: LazyConditionNodeEvaluator;
+
+  setEvaluator(evaluator: LazyConditionNodeEvaluator): void {
+    this.evaluator = evaluator;
+  }
+
+  evaluate(node: LazyConditionEqualsNode, context: unknown): boolean {
+    const operands = node.operands.map(op =>
+      this.evaluator?.evaluate(op, context),
+    );
+
+    return operands.every(op => op === operands[0]);
+  }
+}
+
+export class LazyConditionAstEquals implements LazyConditionAstDef {
+  kind = LazyConditionNodeKindEquals;
+  evaluator = new LazyConditionEqualsEvaluator();
+}

--- a/libs/table/src/lib/lazy-condition/ast/literal.ts
+++ b/libs/table/src/lib/lazy-condition/ast/literal.ts
@@ -1,0 +1,31 @@
+import {
+  LazyConditionAstDef,
+  LazyConditionNode,
+  LazyConditionNodeEvaluator,
+} from '../lazy-condition';
+
+export const LazyConditionNodeKindLiteral = 0;
+
+export interface LazyConditionLiteralNode<T = unknown>
+  extends LazyConditionNode {
+  kind: typeof LazyConditionNodeKindLiteral;
+  literal: T;
+}
+
+export function createLazyConditionLiteral<T>(
+  literal: T,
+): LazyConditionLiteralNode<T> {
+  return { kind: LazyConditionNodeKindLiteral, literal };
+}
+
+export class LazyConditionLiteralEvaluator
+  implements LazyConditionNodeEvaluator<LazyConditionLiteralNode, unknown> {
+  evaluate<T>(node: LazyConditionLiteralNode<T>, context: unknown): T {
+    return node.literal;
+  }
+}
+
+export class LazyConditionAstLiteral implements LazyConditionAstDef {
+  kind = LazyConditionNodeKindLiteral;
+  evaluator = new LazyConditionLiteralEvaluator();
+}

--- a/libs/table/src/lib/lazy-condition/ast/prop.ts
+++ b/libs/table/src/lib/lazy-condition/ast/prop.ts
@@ -1,0 +1,39 @@
+import {
+  LazyConditionAstDef,
+  LazyConditionNode,
+  LazyConditionNodeEvaluator,
+  LazyConditionEvaluator,
+} from '../lazy-condition';
+
+export const LazyConditionNodeKindProp = 3;
+
+export interface LazyConditionPropNode extends LazyConditionNode {
+  kind: typeof LazyConditionNodeKindProp;
+  name: string;
+  object: LazyConditionNode;
+}
+
+export function createLazyConditionProp<T>(
+  name: string,
+  object: LazyConditionNode,
+): LazyConditionPropNode {
+  return { kind: LazyConditionNodeKindProp, name, object };
+}
+
+export class LazyConditionPropEvaluator
+  implements LazyConditionNodeEvaluator<LazyConditionPropNode, unknown> {
+  private evaluator?: LazyConditionNodeEvaluator;
+
+  setEvaluator(evaluator: LazyConditionNodeEvaluator) {
+    this.evaluator = evaluator;
+  }
+
+  evaluate(node: LazyConditionPropNode, context: unknown): unknown {
+    return (this.evaluator?.evaluate(node.object, context) as any)?.[node.name];
+  }
+}
+
+export class LazyConditionAstProp implements LazyConditionAstDef {
+  kind = LazyConditionNodeKindProp;
+  evaluator = new LazyConditionPropEvaluator();
+}

--- a/libs/table/src/lib/lazy-condition/lazy-condition-context.pipe.ts
+++ b/libs/table/src/lib/lazy-condition/lazy-condition-context.pipe.ts
@@ -1,0 +1,13 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+import {
+  createLazyConditionContext,
+  LazyConditionContextNode,
+} from './ast/context';
+
+@Pipe({ name: 'lcCtx' })
+export class ContextPipe implements PipeTransform {
+  transform(property: string): LazyConditionContextNode {
+    return createLazyConditionContext(property);
+  }
+}

--- a/libs/table/src/lib/lazy-condition/lazy-condition-equals.pipe.ts
+++ b/libs/table/src/lib/lazy-condition/lazy-condition-equals.pipe.ts
@@ -1,0 +1,19 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+import {
+  createLazyConditionEquals,
+  LazyConditionEqualsNode,
+} from './ast/equals';
+import { LazyConditionService } from './lazy-condition.service';
+
+@Pipe({ name: 'lcEq' })
+export class EqualsPipe implements PipeTransform {
+  constructor(private lazyConditionService: LazyConditionService) {}
+
+  transform(value: unknown, ...values: unknown[]): LazyConditionEqualsNode {
+    return createLazyConditionEquals([
+      this.lazyConditionService.valueToNode(value),
+      ...values.map(v => this.lazyConditionService.valueToNode(v)),
+    ]);
+  }
+}

--- a/libs/table/src/lib/lazy-condition/lazy-condition-prop.pipe.ts
+++ b/libs/table/src/lib/lazy-condition/lazy-condition-prop.pipe.ts
@@ -1,0 +1,16 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+import { createLazyConditionProp, LazyConditionPropNode } from './ast/prop';
+import { LazyConditionService } from './lazy-condition.service';
+
+@Pipe({ name: 'lcProp' })
+export class PropPipe implements PipeTransform {
+  constructor(private lazyConditionService: LazyConditionService) {}
+
+  transform(obj: unknown, name: string): LazyConditionPropNode {
+    return createLazyConditionProp(
+      name,
+      this.lazyConditionService.valueToNode(obj),
+    );
+  }
+}

--- a/libs/table/src/lib/lazy-condition/lazy-condition.module.ts
+++ b/libs/table/src/lib/lazy-condition/lazy-condition.module.ts
@@ -1,0 +1,13 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+
+import { ContextPipe } from './lazy-condition-context.pipe';
+import { EqualsPipe } from './lazy-condition-equals.pipe';
+import { PropPipe } from './lazy-condition-prop.pipe';
+
+@NgModule({
+  imports: [CommonModule],
+  exports: [EqualsPipe, ContextPipe, PropPipe],
+  declarations: [EqualsPipe, ContextPipe, PropPipe],
+})
+export class LazyConditionModule {}

--- a/libs/table/src/lib/lazy-condition/lazy-condition.service.ts
+++ b/libs/table/src/lib/lazy-condition/lazy-condition.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@angular/core';
+
+import { LazyConditionAstContext } from './ast/context';
+import { LazyConditionAstEquals } from './ast/equals';
+import {
+  createLazyConditionLiteral,
+  LazyConditionAstLiteral,
+} from './ast/literal';
+import { LazyConditionAstProp } from './ast/prop';
+import { LazyConditionEvaluator, LazyConditionNode } from './lazy-condition';
+
+@Injectable({ providedIn: 'root' })
+export class LazyConditionService {
+  private lazyCondition = new LazyConditionEvaluator([
+    new LazyConditionAstLiteral(),
+    new LazyConditionAstEquals(),
+    new LazyConditionAstContext(),
+    new LazyConditionAstProp(),
+  ]);
+
+  evaluate(node: LazyConditionNode, context: unknown): unknown {
+    return this.lazyCondition.eval(node, context);
+  }
+
+  valueToNode(value: unknown): LazyConditionNode {
+    if (value && (value as LazyConditionNode).kind) {
+      return value as LazyConditionNode;
+    }
+
+    return createLazyConditionLiteral(value);
+  }
+}

--- a/libs/table/src/lib/lazy-condition/lazy-condition.ts
+++ b/libs/table/src/lib/lazy-condition/lazy-condition.ts
@@ -1,0 +1,48 @@
+export enum LazyConditionNodeKind {}
+
+export interface LazyConditionNode {
+  kind: unknown;
+}
+
+export interface LazyConditionNodeEvaluator<
+  N = LazyConditionNode,
+  R = unknown
+> {
+  setEvaluator?(evaluator: LazyConditionNodeEvaluator): void;
+  evaluate(node: N, context: unknown): R;
+}
+
+export interface LazyConditionAstDef {
+  kind: LazyConditionNodeKind;
+  evaluator: LazyConditionNodeEvaluator;
+}
+
+export class LazyConditionEvaluator implements LazyConditionNodeEvaluator {
+  private nodeEvaluators: Record<
+    string,
+    LazyConditionNodeEvaluator | undefined
+  > = this.nodeDefs.reduce(
+    (acc, def) => ({ ...acc, [def.kind]: def.evaluator }),
+    Object.create(null),
+  );
+
+  constructor(private nodeDefs: LazyConditionAstDef[]) {}
+
+  eval(node: LazyConditionNode, context: unknown) {
+    // tslint:disable-next-line: no-non-null-assertion
+    Object.values(this.nodeEvaluators).forEach(ev => ev!.setEvaluator?.(this));
+    return this.evaluate(node, context);
+  }
+
+  evaluate(node: LazyConditionNode, context: unknown): unknown {
+    const ev = this.nodeEvaluators[node.kind as string];
+
+    if (!ev) {
+      throw new Error(
+        `LazyConditionEvaluator: Unknown node kind ${node.kind}!`,
+      );
+    }
+
+    return ev.evaluate(node, context);
+  }
+}

--- a/libs/table/src/lib/lazy-condition/test.ts
+++ b/libs/table/src/lib/lazy-condition/test.ts
@@ -1,0 +1,27 @@
+import {
+  LazyConditionAstContext,
+  createLazyConditionContext,
+} from './ast/context';
+import {
+  createLazyConditionEquals,
+  LazyConditionAstEquals,
+} from './ast/equals';
+import {
+  createLazyConditionLiteral,
+  LazyConditionAstLiteral,
+} from './ast/literal';
+import { LazyConditionEvaluator } from './lazy-condition';
+
+const lazyCondition = new LazyConditionEvaluator([
+  new LazyConditionAstLiteral(),
+  new LazyConditionAstEquals(),
+  new LazyConditionAstContext(),
+]);
+
+const lazyConditionAst = createLazyConditionEquals([
+  createLazyConditionContext('prop1'),
+  createLazyConditionLiteral(1),
+]);
+
+console.log(lazyCondition.eval(lazyConditionAst, { prop1: 1 }));
+console.log(lazyCondition.eval(lazyConditionAst, { prop1: 2 }));

--- a/libs/table/src/lib/table-feature/table-feature-tpl.directive.ts
+++ b/libs/table/src/lib/table-feature/table-feature-tpl.directive.ts
@@ -1,6 +1,8 @@
-import { Directive, Input, TemplateRef, OnChanges } from '@angular/core';
-import { ReplaySubject } from 'rxjs';
+import { Directive, Input, OnChanges, TemplateRef } from '@angular/core';
 import { TypedSimpleChanges } from '@spryker/utils';
+import { ReplaySubject } from 'rxjs';
+
+import { LazyConditionNode } from '../lazy-condition/lazy-condition';
 
 export interface TableFeatureTplContext {
   [key: string]: any;
@@ -9,6 +11,7 @@ export interface TableFeatureTplContext {
 export class TableFeatureTplDirectiveInputs {
   @Input() spyTableFeatureTpl?: string | string[];
   @Input() spyTableFeatureTplStyles?: Record<string, any>;
+  @Input() spyTableFeatureTplCondition?: LazyConditionNode;
 }
 
 @Directive({
@@ -18,6 +21,7 @@ export class TableFeatureTplDirective extends TableFeatureTplDirectiveInputs
   implements OnChanges {
   locations$ = new ReplaySubject<string[]>(1);
   styles$ = new ReplaySubject<Record<string, any>>(1);
+  condition$ = new ReplaySubject<LazyConditionNode>(1);
 
   constructor(public template: TemplateRef<TableFeatureTplContext>) {
     super();
@@ -38,6 +42,10 @@ export class TableFeatureTplDirective extends TableFeatureTplDirectiveInputs
 
     if (changes.spyTableFeatureTplStyles) {
       this.styles$.next(this.spyTableFeatureTplStyles);
+    }
+
+    if (changes.spyTableFeatureTplCondition) {
+      this.condition$.next(this.spyTableFeatureTplCondition);
     }
   }
 }

--- a/libs/table/src/lib/table-features-renderer/table-features-renderer.directive.ts
+++ b/libs/table/src/lib/table-features-renderer/table-features-renderer.directive.ts
@@ -103,6 +103,7 @@ export class TableFeaturesRendererDirective
         this.featuresRendererService.trackFeatureRecords(
           this.spyTableFeaturesRendererFeatures,
           this.spyTableFeaturesRenderer,
+          this.spyTableFeaturesRendererContext,
         ),
       );
     }

--- a/libs/table/src/lib/table/table.component.html
+++ b/libs/table/src/lib/table/table.component.html
@@ -63,53 +63,90 @@
   </thead>
 
   <tbody>
-    <tr
+    <ng-container
       *ngFor="
         let data of tableData$ | async;
         trackBy: trackByData;
         index as indexOfElement
       "
-      [ngClass]="rowClasses[indexOfElement]"
     >
       <ng-template
-        [spyTableFeaturesRenderer]="featureLocation.beforeCols"
+        [spyTableFeaturesRenderer]="featureLocation.beforeRow"
         [spyTableFeaturesRendererFeatures]="features$ | async"
-        [spyTableFeaturesRendererContext]="{ data: data, i: indexOfElement }"
+        [spyTableFeaturesRendererContext]="{
+          data: data,
+          i: indexOfElement,
+          columns: columns$ | async
+        }"
         let-feature
       >
-        <td [ngStyle]="feature.featureStyles$ | async">
-          <div class="ant-table-column-inner">
-            <ng-template [spyTableRenderFeature]="feature"></ng-template>
-          </div>
-        </td>
+        <tr
+          class="ant-table-row-ext ant-table-row-ext__before ant-table-features ant-table-features--before-row"
+          [ngClass]="rowClasses[indexOfElement]"
+        >
+          <ng-container *spyTableRenderFeature="feature"></ng-container>
+        </tr>
       </ng-template>
 
-      <td *ngFor="let column of columns$ | async; trackBy: trackByColumns">
-        <div class="ant-table-column-inner">
-          <spy-table-column-renderer
-            [config]="column"
-            [data]="data"
-            [template]="templatesObj[column.id]"
-            [i]="indexOfElement"
-          ></spy-table-column-renderer>
-        </div>
-      </td>
+      <tr [ngClass]="rowClasses[indexOfElement]">
+        <ng-template
+          [spyTableFeaturesRenderer]="featureLocation.beforeCols"
+          [spyTableFeaturesRendererFeatures]="features$ | async"
+          [spyTableFeaturesRendererContext]="{ data: data, i: indexOfElement }"
+          let-feature
+        >
+          <td [ngStyle]="feature.featureStyles$ | async">
+            <div class="ant-table-column-inner">
+              <ng-template [spyTableRenderFeature]="feature"></ng-template>
+            </div>
+          </td>
+        </ng-template>
+
+        <td *ngFor="let column of columns$ | async; trackBy: trackByColumns">
+          <div class="ant-table-column-inner">
+            <spy-table-column-renderer
+              [config]="column"
+              [data]="data"
+              [template]="templatesObj[column.id]"
+              [i]="indexOfElement"
+            ></spy-table-column-renderer>
+          </div>
+        </td>
+
+        <ng-template
+          [spyTableFeaturesRenderer]="featureLocation.afterCols"
+          [spyTableFeaturesRendererFeatures]="features$ | async"
+          [spyTableFeaturesRendererContext]="{ data: data, i: indexOfElement }"
+          let-feature
+        >
+          <td [ngStyle]="feature.featureStyles$ | async">
+            <div
+              class="ant-table-column-inner ant-table-column-inner--align-right"
+            >
+              <ng-template [spyTableRenderFeature]="feature"></ng-template>
+            </div>
+          </td>
+        </ng-template>
+      </tr>
 
       <ng-template
-        [spyTableFeaturesRenderer]="featureLocation.afterCols"
+        [spyTableFeaturesRenderer]="featureLocation.afterRow"
         [spyTableFeaturesRendererFeatures]="features$ | async"
-        [spyTableFeaturesRendererContext]="{ data: data, i: indexOfElement }"
+        [spyTableFeaturesRendererContext]="{
+          data: data,
+          i: indexOfElement,
+          columns: columns$ | async
+        }"
         let-feature
       >
-        <td [ngStyle]="feature.featureStyles$ | async">
-          <div
-            class="ant-table-column-inner ant-table-column-inner--align-right"
-          >
-            <ng-template [spyTableRenderFeature]="feature"></ng-template>
-          </div>
-        </td>
+        <tr
+          class="ant-table-row-ext ant-table-row-ext__after ant-table-features ant-table-features--after-row"
+          [ngClass]="rowClasses[indexOfElement]"
+        >
+          <ng-container *spyTableRenderFeature="feature"></ng-container>
+        </tr>
       </ng-template>
-    </tr>
+    </ng-container>
   </tbody>
 </nz-table>
 
@@ -144,3 +181,9 @@
 >
   <ng-content select="[spy-table-feature]"></ng-content>
 </span>
+
+<ng-template #rowExt let-columns>
+  <td [attr.colspan]="columns.length">
+    <div class="ant-table-column-inner">TEST</div>
+  </td>
+</ng-template>

--- a/libs/table/src/lib/table/table.ts
+++ b/libs/table/src/lib/table/table.ts
@@ -114,6 +114,8 @@ export enum TableFeatureLocation {
   beforeCols = 'before-cols',
   afterColsHeader = 'after-cols-header',
   afterCols = 'after-cols',
+  beforeRow = 'before-row',
+  afterRow = 'after-row',
   afterTable = 'after-table',
   bottom = 'bottom',
   hidden = 'hidden',


### PR DESCRIPTION
This PR explores ways to add table row extentions before and after rows with conditions.

The idea is that table will render extra `tr` before and after the main data row with features.

The main challenge is to be able to control when row extensions should be render and when not per data row basis. For example, row extension might be only needed for first row, or extension is only needed for every odd row, or extension is only needed when some other condition is met.

For this purpose custom DSL is created that allows to express conditions lazily and then execute them as rendering happens per each row. It operates on the so called "context" object that can be accessed during execution.

Every row has it's own context that contains: data, index, columns.

Custom lazy DSL is designed to be minimal and extendable - it's AST can be easily extended without modifying any existing code of the DSL.

AST of lazy DSL mainly requires 2 parts:
- node kind (unique integer)
- node evaluator - it's an interface that is used to evaluate single node of it's kind with ability to do recursive evaluation

As of now lazy DSL has the following AST nodes:
- Literal - it captures any value as a literal
- Equals - it captures many nodes, evaluates them recursively and compares if they are equal
- Context - it accesses context by property name and returns it
- Prop - it accesses any property on an object node that is evaluated recursively

Construction of the lazy DSL may be done directly via JS calls but it's preferred usage is via Angular template using pipes that expose AST nodes. Every AST node has a pipe that creates it and chain of such pipes can create complex and expressive DSL.

**Example 1: I want extend second row.**
Then my condition DSL would look like:
```html
<div
  *spyTableFeatureTpl="
      tableFeatureLocation.afterRow;
      condition: 'i' | lcCtx | lcEq: 1
  ">Extends second row</div>
```
This reads as following:
1. Access property `i` from context object via `lcCtx` pipe
2. Compare it's value with literal `1` via `lcEq` pipe

**Example 2: I want to extend rows whose column `col1` value is set to `col1 #2`**
Then my condition DSL would look like:
```html
<div
  *spyTableFeatureTpl="
      tableFeatureLocation.afterRow;
      condition: 'data' | lcCtx | lcProp: 'col1' | lcEq: 'col1 #2'
  ">Extends second row</div>
```
This reads as following:
1. Access property `data` from context object via `lcCtx` pipe
2. Access property `col1` from it's value via `lcProp` pipe
3. Compare it's value with literal `col1 #2` via `lcEq` pipe
