### PR TITLE
[Infra] Enable NX Workspace caching

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -27,67 +27,87 @@
       "tags": ["pkg:primary", "type:util"]
     },
     "button": {
-      "tags": ["pkg:primary", "type:component", "level:atom"]
+      "tags": ["pkg:primary", "type:component", "level:atom"],
+      "implicitDependencies": ["styles"]
     },
     "logo": {
-      "tags": ["pkg:primary", "level:atom", "type:component"]
+      "tags": ["pkg:primary", "level:atom", "type:component"],
+      "implicitDependencies": ["styles"]
     },
     "card": {
-      "tags": ["pkg:primary", "level:atom", "type:component"]
+      "tags": ["pkg:primary", "level:atom", "type:component"],
+      "implicitDependencies": ["styles"]
     },
     "form-item": {
-      "tags": ["pkg:primary", "level:atom", "type:component"]
+      "tags": ["pkg:primary", "level:atom", "type:component"],
+      "implicitDependencies": ["styles"]
     },
     "input": {
-      "tags": ["pkg:primary", "level:atom", "type:component"]
+      "tags": ["pkg:primary", "level:atom", "type:component"],
+      "implicitDependencies": ["styles"]
     },
     "layout": {
-      "tags": ["pkg:primary", "level:atom", "type:component"]
+      "tags": ["pkg:primary", "level:atom", "type:component"],
+      "implicitDependencies": ["styles"]
     },
     "header": {
-      "tags": ["pkg:primary", "level:organism", "type:component"]
+      "tags": ["pkg:primary", "level:organism", "type:component"],
+      "implicitDependencies": ["styles"]
     },
     "navigation": {
-      "tags": ["pkg:primary", "level:molecule", "type:component-service"]
+      "tags": ["pkg:primary", "level:molecule", "type:component-service"],
+      "implicitDependencies": ["styles"]
     },
     "icon": {
-      "tags": ["pkg:primary", "level:atom", "type:component"]
+      "tags": ["pkg:primary", "level:atom", "type:component"],
+      "implicitDependencies": ["styles"]
     },
     "sidebar": {
-      "tags": ["pkg:primary", "level:molecule", "type:component"]
+      "tags": ["pkg:primary", "level:molecule", "type:component"],
+      "implicitDependencies": ["styles"]
     },
     "textarea": {
-      "tags": ["pkg:primary", "level:atom", "type:component"]
+      "tags": ["pkg:primary", "level:atom", "type:component"],
+      "implicitDependencies": ["styles"]
     },
     "toggle": {
-      "tags": ["pkg:primary", "level:atom", "type:component"]
+      "tags": ["pkg:primary", "level:atom", "type:component"],
+      "implicitDependencies": ["styles"]
     },
     "checkbox": {
-      "tags": ["pkg:primary", "level:atom", "type:component"]
+      "tags": ["pkg:primary", "level:atom", "type:component"],
+      "implicitDependencies": ["styles"]
     },
     "collapsible": {
       "tags": ["pkg:primary", "level:molecule", "type:component"]
     },
     "select": {
-      "tags": ["pkg:primary", "level:molecule", "type:component"]
+      "tags": ["pkg:primary", "level:molecule", "type:component"],
+      "implicitDependencies": ["styles", "locale"]
     },
     "notification": {
-      "tags": ["pkg:primary", "level:molecule", "type:component-service"]
+      "tags": ["pkg:primary", "level:molecule", "type:component-service"],
+      "implicitDependencies": ["styles"]
     },
     "table": {
-      "tags": ["pkg:primary", "level:organism", "type:component-service"]
+      "tags": ["pkg:primary", "level:organism", "type:component-service"],
+      "implicitDependencies": ["styles", "locale"]
     },
     "pagination": {
-      "tags": ["pkg:primary", "level:molecule", "type:component"]
+      "tags": ["pkg:primary", "level:molecule", "type:component"],
+      "implicitDependencies": ["styles", "locale"]
     },
     "dropdown": {
-      "tags": ["pkg:primary", "level:molecule", "type:component"]
+      "tags": ["pkg:primary", "level:molecule", "type:component"],
+      "implicitDependencies": ["styles"]
     },
     "tabs": {
-      "tags": ["pkg:primary", "level:molecule", "type:component"]
+      "tags": ["pkg:primary", "level:molecule", "type:component"],
+      "implicitDependencies": ["styles"]
     },
     "label": {
-      "tags": ["pkg:primary", "level:atom", "type:component"]
+      "tags": ["pkg:primary", "level:atom", "type:component"],
+      "implicitDependencies": ["styles"]
     },
     "internal-utils": {
       "tags": ["pkg:primary", "type:meta"]
@@ -96,10 +116,12 @@
       "tags": ["pkg:primary", "type:util"]
     },
     "chips": {
-      "tags": ["pkg:primary", "level:atom", "type:component"]
+      "tags": ["pkg:primary", "level:atom", "type:component"],
+      "implicitDependencies": ["styles"]
     },
     "date-picker": {
-      "tags": ["pkg:primary", "level:molecule", "type:component"]
+      "tags": ["pkg:primary", "level:molecule", "type:component"],
+      "implicitDependencies": ["styles", "locale"]
     },
     "ajax-action": {
       "tags": ["pkg:primary", "type:service"]
@@ -117,25 +139,31 @@
       "tags": ["pkg:primary", "level:molecule", "type:component"]
     },
     "drawer": {
-      "tags": ["pkg:primary", "level:molecule", "type:component-service"]
+      "tags": ["pkg:primary", "level:molecule", "type:component-service"],
+      "implicitDependencies": ["styles"]
     },
     "ajax-form": {
       "tags": ["pkg:primary", "level:molecule", "type:component"]
     },
     "headline": {
-      "tags": ["pkg:primary", "level:atom", "type:component"]
+      "tags": ["pkg:primary", "level:atom", "type:component"],
+      "implicitDependencies": ["styles"]
     },
     "popover": {
-      "tags": ["pkg:primary", "level:molecule", "type:component"]
+      "tags": ["pkg:primary", "level:molecule", "type:component"],
+      "implicitDependencies": ["styles"]
     },
     "tree-select": {
-      "tags": ["pkg:primary", "level:molecule", "type:component"]
+      "tags": ["pkg:primary", "level:molecule", "type:component"],
+      "implicitDependencies": ["styles", "locale"]
     },
     "link": {
-      "tags": ["pkg:primary", "level:atom", "type:component"]
+      "tags": ["pkg:primary", "level:atom", "type:component"],
+      "implicitDependencies": ["styles"]
     },
     "table.feature.editable": {
-      "tags": ["type:component", "level:molecule", "pkg:extension"]
+      "tags": ["type:component", "level:molecule", "pkg:extension"],
+      "implicitDependencies": ["styles", "locale"]
     },
     "ajax-action.post-action.refresh-drawer": {
       "tags": ["type:service", "pkg:extension"]
@@ -156,49 +184,63 @@
       "tags": ["level:atom", "type:component", "pkg:extension"]
     },
     "table.feature.pagination": {
-      "tags": ["level:molecule", "type:component", "pkg:extension"]
+      "tags": ["level:molecule", "type:component", "pkg:extension"],
+      "implicitDependencies": ["styles"]
     },
     "table.feature.total": {
-      "tags": ["level:molecule", "type:component", "pkg:extension"]
+      "tags": ["level:molecule", "type:component", "pkg:extension"],
+      "implicitDependencies": ["styles", "locale"]
     },
     "table.feature.title": {
-      "tags": ["level:molecule", "type:component", "pkg:extension"]
+      "tags": ["level:molecule", "type:component", "pkg:extension"],
+      "implicitDependencies": ["styles"]
     },
     "table.feature.filters": {
-      "tags": ["level:molecule", "type:component", "pkg:extension"]
+      "tags": ["level:molecule", "type:component", "pkg:extension"],
+      "implicitDependencies": ["styles"]
     },
     "table.feature.settings": {
-      "tags": ["level:molecule", "type:component", "pkg:extension"]
+      "tags": ["level:molecule", "type:component", "pkg:extension"],
+      "implicitDependencies": ["styles", "locale"]
     },
     "table.feature.selectable": {
-      "tags": ["level:molecule", "type:component", "pkg:extension"]
+      "tags": ["level:molecule", "type:component", "pkg:extension"],
+      "implicitDependencies": ["styles"]
     },
     "table.feature.search": {
-      "tags": ["level:molecule", "type:component", "pkg:extension"]
+      "tags": ["level:molecule", "type:component", "pkg:extension"],
+      "implicitDependencies": ["styles"]
     },
     "table.feature.sync-state": {
       "tags": ["level:molecule", "type:component", "pkg:extension"]
     },
     "table.feature.batch-actions": {
-      "tags": ["level:molecule", "type:component", "pkg:extension"]
+      "tags": ["level:molecule", "type:component", "pkg:extension"],
+      "implicitDependencies": ["styles"]
     },
     "table.feature.row-actions": {
-      "tags": ["level:molecule", "type:component", "pkg:extension"]
+      "tags": ["level:molecule", "type:component", "pkg:extension"],
+      "implicitDependencies": ["styles"]
     },
     "table.filter.select": {
-      "tags": ["level:molecule", "type:component", "pkg:extension"]
+      "tags": ["level:molecule", "type:component", "pkg:extension"],
+      "implicitDependencies": ["locale"]
     },
     "table.filter.date-range": {
-      "tags": ["level:molecule", "type:component", "pkg:extension"]
+      "tags": ["level:molecule", "type:component", "pkg:extension"],
+      "implicitDependencies": ["styles", "locale"]
     },
     "table.filter.tree-select": {
-      "tags": ["level:molecule", "type:component", "pkg:extension"]
+      "tags": ["level:molecule", "type:component", "pkg:extension"],
+      "implicitDependencies": ["locale"]
     },
     "table.action-handler.form-overlay": {
-      "tags": ["level:molecule", "type:component-service", "pkg:extension"]
+      "tags": ["level:molecule", "type:component-service", "pkg:extension"],
+      "implicitDependencies": ["styles"]
     },
     "table.action-handler.html-overlay": {
-      "tags": ["level:molecule", "type:component-service", "pkg:extension"]
+      "tags": ["level:molecule", "type:component-service", "pkg:extension"],
+      "implicitDependencies": ["styles"]
     },
     "table.action-handler.url": {
       "tags": ["type:service", "pkg:extension"]
@@ -207,7 +249,8 @@
       "tags": ["type:meta"]
     },
     "modal": {
-      "tags": ["level:molecule", "type:component-service", "pkg:primary"]
+      "tags": ["level:molecule", "type:component-service", "pkg:primary"],
+      "implicitDependencies": ["styles", "locale"]
     },
     "interception": {
       "tags": ["type:service", "pkg:primary"]
@@ -228,7 +271,8 @@
       "tags": ["type:component", "level:atom", "pkg:extension"]
     },
     "table.column.select": {
-      "tags": ["type:component", "level:molecule", "pkg:extension"]
+      "tags": ["type:component", "level:molecule", "pkg:extension"],
+      "implicitDependencies": ["locale"]
     },
     "table.datasource.inline": {
       "tags": ["type:service", "pkg:extension"]
@@ -240,16 +284,19 @@
       "tags": ["type:service", "pkg:extension"]
     },
     "grid": {
-      "tags": ["pkg:primary", "type:style"]
+      "tags": ["pkg:primary", "type:style"],
+      "implicitDependencies": ["styles"]
     },
     "data-serializer": {
       "tags": ["type:service", "pkg:primary"]
     },
     "radio": {
-      "tags": ["level:atom", "type:component", "pkg:primary"]
+      "tags": ["level:atom", "type:component", "pkg:primary"],
+      "implicitDependencies": ["styles"]
     },
     "autocomplete": {
-      "tags": ["level:molecule", "type:component", "pkg:primary"]
+      "tags": ["level:molecule", "type:component", "pkg:primary"],
+      "implicitDependencies": ["styles"]
     },
     "persistence": {
       "tags": ["type:service", "pkg:primary"]
@@ -263,15 +310,18 @@
   },
   "tasksRunnerOptions": {
     "default": {
-      "runner": "@nrwl/workspace/tasks-runners/default",
+      "runner": "@nrwl/nx-cloud",
       "options": {
+        "accessToken": "MmFmYTcwM2MtNDI4Ny00ZDVkLTg1YjktYzZiYjI0ZWVkODU1fHJlYWQtd3JpdGU=",
         "cacheableOperations": [
           "build",
-          "lint",
           "test",
+          "lint",
           "e2e",
           "build-storybook"
-        ]
+        ],
+        "canTrackAnalytics": false,
+        "showUsageWarnings": true
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6798,6 +6798,31 @@
         "@angular-devkit/schematics": "~9.1.0"
       }
     },
+    "@nrwl/nx-cloud": {
+      "version": "9.3.5",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-cloud/-/nx-cloud-9.3.5.tgz",
+      "integrity": "sha512-zVF1FZbtxMRi+rC0Tg8dl90oBNlsYIfIxcs4vaBJmk2U80povO4MuVFie5mKrsvYeA4BJu6rdOqgRTA/dENTig==",
+      "requires": {
+        "axios": "^0.19.0",
+        "node-machine-id": "^1.1.12",
+        "tar": "5.0.5"
+      },
+      "dependencies": {
+        "tar": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-5.0.5.tgz",
+          "integrity": "sha512-MNIgJddrV2TkuwChwcSNds/5E9VijOiw7kAc1y5hTNJoLDSuIyid2QtLYiCYNnICebpuvjhPQZsXwUL0O3l7OQ==",
+          "requires": {
+            "chownr": "^1.1.3",
+            "fs-minipass": "^2.0.0",
+            "minipass": "^3.0.0",
+            "minizlib": "^2.1.0",
+            "mkdirp": "^0.5.0",
+            "yallist": "^4.0.0"
+          }
+        }
+      }
+    },
     "@nrwl/storybook": {
       "version": "9.5.1",
       "resolved": "https://registry.npmjs.org/@nrwl/storybook/-/storybook-9.5.1.tgz",
@@ -12089,7 +12114,6 @@
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
       "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
-      "dev": true,
       "requires": {
         "follow-redirects": "1.5.10"
       },
@@ -12098,7 +12122,6 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -12107,7 +12130,6 @@
           "version": "1.5.10",
           "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
           "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-          "dev": true,
           "requires": {
             "debug": "=3.1.0"
           }
@@ -12115,8 +12137,7 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
@@ -13836,8 +13857,7 @@
     "chownr": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "dev": true
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
     "chrome-trace-event": {
       "version": "1.0.2",
@@ -19449,7 +19469,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
       "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-      "dev": true,
       "requires": {
         "minipass": "^3.0.0"
       }
@@ -26631,8 +26650,7 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "minimist-options": {
       "version": "4.1.0",
@@ -26657,7 +26675,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
       "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -26693,7 +26710,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.0.tgz",
       "integrity": "sha512-EzTZN/fjSvifSX0SlqUERCN39o6T40AMarPbv0MrarSFtIITCBh7bi+dU8nxGFHuqs9jdIAeoYoKuQAAASsPPA==",
-      "dev": true,
       "requires": {
         "minipass": "^3.0.0",
         "yallist": "^4.0.0"
@@ -26742,7 +26758,6 @@
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
       "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-      "dev": true,
       "requires": {
         "minimist": "^1.2.5"
       }
@@ -27570,6 +27585,11 @@
           "dev": true
         }
       }
+    },
+    "node-machine-id": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/node-machine-id/-/node-machine-id-1.1.12.tgz",
+      "integrity": "sha512-QNABxbrPa3qEIfrE6GOJ7BYIuignnJw7iQ2YPbc3Nla1HzRJjXzZOiikfF8m7eAMfichLt3M4VgLOetqgDmgGQ=="
     },
     "node-modules-regexp": {
       "version": "1.0.0",
@@ -37961,8 +37981,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yaml": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "@angular/platform-browser": "^9.1.12",
     "@angular/platform-browser-dynamic": "^9.1.12",
     "@angular/router": "^9.1.12",
+    "@nrwl/nx-cloud": "^9.3.5",
     "@orchestrator/core": "^0.2.0",
     "@orchestrator/layout": "^0.1.0",
     "core-js": "^3.6.4",


### PR DESCRIPTION
This PR enables NX Workspace caching feature that uses NX Cloud to speed up our CI pipeline.

It uses free tier coupon that gives 5 hours in cloud every month for caching.

**Time saved in CI by this optimization is: ~12 min.**

> Note: This is the maximum time saved possible since no changes were made in the second commit.
> In real scenario time saving will be slightly less depending on the amount of packages changed.

Full CI: 15 min 50 sec https://travis-ci.com/github/spryker/ui-components/builds/172514609
Cached CI: 4 min 19 sec https://travis-ci.com/github/spryker/ui-components/builds/172521758
