### PR TITLE
[POC] Dependable editable table columns

### DIFF
--- a/libs/table.column.select/src/lib/table-column-select.component.html
+++ b/libs/table.column.select/src/lib/table-column-select.component.html
@@ -18,6 +18,7 @@
       [showSelectAll]="config?.showSelectAll | context: context"
       [selectAllTitle]="config?.selectAllTitle | context: context"
       [noOptionsText]="config?.noOptionsText | context: context"
+      [datasource]="config?.datasource"
       (valueChange)="valueChangeHandler($event)"
       control
     ></spy-select>

--- a/libs/table.column.select/src/lib/table-column-select.component.ts
+++ b/libs/table.column.select/src/lib/table-column-select.component.ts
@@ -12,6 +12,7 @@ import {
   TableColumnComponent,
   TableColumnContext,
   TableColumnTypeComponent,
+  TableDatasourceConfig,
 } from '@spryker/table';
 import { TableEditableService } from '@spryker/table.feature.editable';
 
@@ -72,6 +73,8 @@ export class TableColumnSelectConfig {
     value: [String, Boolean],
   })
   editableError?: string | boolean;
+  @ColumnTypeOption()
+  datasource?: TableDatasourceConfig;
 }
 
 @Component({

--- a/libs/table.feature.editable/src/index.ts
+++ b/libs/table.feature.editable/src/index.ts
@@ -3,3 +3,4 @@ export * from './lib/types';
 export * from './lib/table-editable-feature.module';
 export * from './lib/table-editable-feature.component';
 export * from './lib/table-editable-feature.service';
+export * from './lib/table-dependable-datasource.service';

--- a/libs/table.feature.editable/src/lib/table-dependable-datasource.service.ts
+++ b/libs/table.feature.editable/src/lib/table-dependable-datasource.service.ts
@@ -1,0 +1,59 @@
+import { Injectable, Injector } from '@angular/core';
+import { LOCAL_GET_CONTEXT, LocalGetContextToken } from '@orchestrator/core';
+import {
+  CoreTableComponent,
+  TableColumnContext,
+  TableData,
+  TableDataConfig,
+  TableDatasource,
+  TableDatasourceConfig,
+  TableDatasourceService,
+} from '@spryker/table';
+import { EMPTY, Observable } from 'rxjs';
+import { map, startWith, switchMap, tap } from 'rxjs/operators';
+
+import { TableEditableFeatureComponent } from './table-editable-feature.component';
+
+export interface TableDependableDatasourceConfig extends TableDatasourceConfig {
+  /** ID of the dependent column */
+  dependsOn: string;
+  datasource: TableDatasourceConfig;
+}
+
+@Injectable({ providedIn: 'root' })
+export class TableDependableDatasourceService
+  implements TableDatasource<TableDependableDatasourceConfig> {
+  resolve(
+    datasource: TableDependableDatasourceConfig,
+    dataConfig$: Observable<TableDataConfig>,
+    injector: Injector,
+  ): Observable<TableData> {
+    const datasourceService = injector.get(TableDatasourceService);
+    const tableComponent = injector.get(CoreTableComponent);
+
+    const getContext = injector.get<LocalGetContextToken>(LOCAL_GET_CONTEXT);
+    const editableService$ = tableComponent
+      .findFeatureByType(TableEditableFeatureComponent)
+      .pipe(map((editableFeature) => editableFeature.tableEditableService));
+
+    const context: TableColumnContext = getContext();
+
+    return editableService$.pipe(
+      switchMap((editableService) =>
+        editableService
+          ? editableService
+              .getUpdatesFor(datasource.dependsOn, context.i)
+              .pipe(
+                startWith(
+                  editableService.getValueFor(datasource.dependsOn, context.i),
+                ),
+              )
+          : EMPTY,
+      ),
+      switchMap((value) => datasourceService.resolve(datasource.datasource)),
+      tap((data) =>
+        console.log('From datasourse', datasource.datasource, data),
+      ),
+    );
+  }
+}

--- a/libs/table.feature.editable/src/lib/table-editable-feature.component.ts
+++ b/libs/table.feature.editable/src/lib/table-editable-feature.component.ts
@@ -51,6 +51,7 @@ import {
   tap,
 } from 'rxjs/operators';
 
+import { TableEditableService } from './table-editable.service';
 import { TableEditableEditRequestToken } from './tokens';
 import {
   TableEditableColumn,
@@ -87,6 +88,7 @@ interface TableEditCellModel {
       useExisting: TableEditableFeatureComponent,
     },
     provideInvokeContext(TableEditableFeatureComponent),
+    TableEditableService,
   ],
 })
 export class TableEditableFeatureComponent
@@ -102,20 +104,6 @@ export class TableEditableFeatureComponent
   buttonSize = ButtonSize;
   buttonVariant = ButtonVariant;
 
-  constructor(
-    injector: Injector,
-    private cdr: ChangeDetectorRef,
-    private ajaxActionService: AjaxActionService,
-    private contextService: ContextService,
-    private httpClient: HttpClient,
-    private tableFeaturesRendererService: TableFeaturesRendererService,
-    private resizeObserver: NzResizeObserver,
-    private zone: NgZone,
-    private dataSerializerService: DataSerializerService,
-  ) {
-    super(injector);
-  }
-
   syncInput: TableDataRow[] = [];
   stringifiedSyncInput?: string;
   url?: TableEditableConfigUrl;
@@ -125,7 +113,10 @@ export class TableEditableFeatureComponent
   private tableElement?: HTMLElement;
 
   private destroyed$ = new Subject<void>();
+
   tableColumns$ = this.table$.pipe(switchMap((table) => table.columns$));
+  tableData$ = this.table$.pipe(switchMap((table) => table.data$));
+
   isAfterColsFeaturesExist$ = this.table$.pipe(
     switchMap((table) => table.features$),
     switchMap((features) =>
@@ -210,6 +201,13 @@ export class TableEditableFeatureComponent
       this.updateFloatCellPosition();
     }),
   );
+  private updateEditableData$ = this.tableData$.pipe(
+    tap(({ data }) => {
+      this.tableEditableService.reset();
+      this.syncInput.forEach((row) => this.tableEditableService.addRow(row));
+      data.forEach((row) => this.tableEditableService.addRow(row));
+    }),
+  );
   private shouldUnsubscribe$ = merge(
     this.destroyed$,
     this.updateTableElement$.pipe(
@@ -219,6 +217,21 @@ export class TableEditableFeatureComponent
     ),
   );
 
+  constructor(
+    injector: Injector,
+    private cdr: ChangeDetectorRef,
+    private ajaxActionService: AjaxActionService,
+    private contextService: ContextService,
+    private httpClient: HttpClient,
+    private tableFeaturesRendererService: TableFeaturesRendererService,
+    private resizeObserver: NzResizeObserver,
+    private zone: NgZone,
+    private dataSerializerService: DataSerializerService,
+    public tableEditableService: TableEditableService,
+  ) {
+    super(injector);
+  }
+
   ngOnInit() {
     this.updateFloatCellsPosition$
       .pipe(takeUntil(this.shouldUnsubscribe$))
@@ -226,6 +239,7 @@ export class TableEditableFeatureComponent
     this.updateFloatCellsPositionOnColumnConfigurator$
       .pipe(takeUntil(this.shouldUnsubscribe$))
       .subscribe();
+    this.updateEditableData$.pipe(takeUntil(this.destroyed$)).subscribe();
   }
 
   ngAfterViewChecked(): void {
@@ -318,6 +332,9 @@ export class TableEditableFeatureComponent
    */
   addRow(mockRowData: TableDataRow): void {
     this.syncInput = [{ ...mockRowData }, ...this.syncInput];
+
+    this.tableEditableService.addRow(mockRowData);
+
     this.stringifiedSyncInput = JSON.stringify(this.syncInput);
     this.updateRows$.next(this.syncInput);
     this.increaseRowErrorsIndex();
@@ -332,6 +349,9 @@ export class TableEditableFeatureComponent
 
     this.syncInput = [...this.syncInput];
     this.syncInput[index][colId] = value;
+
+    this.tableEditableService.updateModel(value, colId, index);
+
     this.stringifiedSyncInput = JSON.stringify(this.syncInput);
     this.updateRows$.next(this.syncInput);
     this.cdr.markForCheck();
@@ -351,6 +371,9 @@ export class TableEditableFeatureComponent
     syncInput.splice(index, 1);
 
     this.syncInput = syncInput;
+
+    this.tableEditableService.removeRow(index);
+
     this.stringifiedSyncInput = JSON.stringify(this.syncInput);
     this.updateRows$.next(this.syncInput);
     this.decreaseRowErrorsIndex(index);
@@ -499,11 +522,11 @@ export class TableEditableFeatureComponent
       url,
       (cellContext as unknown) as AnyContext,
     );
+    // tslint:disable-next-line: no-non-null-assertion
+    const value = this.editingModel[cellContext.i][cellContext.config.id]!
+      .value;
     const requestData = {
-      // tslint:disable-next-line: no-non-null-assertion
-      [cellContext.config.id]: this.editingModel[cellContext.i][
-        cellContext.config.id
-      ]!.value,
+      [cellContext.config.id]: value,
     };
 
     this.httpClient
@@ -520,6 +543,11 @@ export class TableEditableFeatureComponent
         (response) => {
           this.ajaxActionService.handle(response, this.injector);
           this.closeEditableCell(cellContext.i, cellContext.config.id);
+          this.tableEditableService.updateModel(
+            value,
+            cellContext.config.id,
+            cellContext.i + this.syncInput.length,
+          );
         },
         (error) => {
           this.editingModel = { ...this.editingModel };

--- a/libs/table.feature.editable/src/lib/table-editable.service.ts
+++ b/libs/table.feature.editable/src/lib/table-editable.service.ts
@@ -1,0 +1,98 @@
+import { Injectable, OnDestroy } from '@angular/core';
+import { Observable, OperatorFunction, Subject } from 'rxjs';
+import { distinctUntilChanged, map, scan } from 'rxjs/operators';
+
+interface ModelOperationAdd {
+  rowAddedAt: number;
+}
+
+interface ModelOperationUpdate {
+  rowUpdatedAt: number;
+}
+
+interface ModelOperationRemove {
+  rowRemovedAt: number;
+}
+
+type ModelOperation =
+  | ModelOperationAdd
+  | ModelOperationUpdate
+  | ModelOperationRemove;
+
+@Injectable()
+export class TableEditableService implements OnDestroy {
+  private model: Record<string, unknown>[] = [];
+  private modelUpdates$ = new Subject<ModelOperation>();
+
+  ngOnDestroy(): void {
+    this.reset();
+  }
+
+  reset() {
+    this.model = [];
+  }
+
+  addRow(rowModel: Record<string, unknown>) {
+    this.model.unshift(rowModel);
+    this.modelUpdates$.next({ rowAddedAt: 0 });
+  }
+
+  updateModel(value: unknown, colId: string, rowIdx: number) {
+    this.maybeInitRows(rowIdx);
+
+    this.model[rowIdx][colId] = value;
+    this.modelUpdates$.next({ rowAddedAt: rowIdx });
+  }
+
+  removeRow(rowIdx: number) {
+    if (rowIdx >= this.model.length) {
+      return;
+    }
+
+    this.model.splice(rowIdx, 1);
+    this.modelUpdates$.next({ rowRemovedAt: rowIdx });
+  }
+
+  getValueFor(colId: string, rowIdx: number): unknown {
+    return this.model?.[rowIdx]?.[colId];
+  }
+
+  getUpdatesFor(colId: string, rowIdx: number): Observable<unknown> {
+    return this.modelUpdates$.pipe(
+      this.trackRowIdx(rowIdx),
+      map((trackedRowIdx) => this.getValueFor(colId, trackedRowIdx)),
+      distinctUntilChanged(),
+    );
+  }
+
+  private maybeInitRows(rowIdx: number) {
+    const rowsDiff = rowIdx - this.model.length + 1;
+
+    if (rowsDiff < 1) {
+      return;
+    }
+
+    for (let i = 0; i < rowsDiff; i++) {
+      this.model.push({});
+    }
+  }
+
+  private trackRowIdx(
+    originalRowIdx: number,
+  ): OperatorFunction<ModelOperation, number> {
+    return (o$) =>
+      o$.pipe(
+        scan((lastRowIdx, update) => {
+          if ('rowAddedAt' in update && lastRowIdx >= update.rowAddedAt) {
+            return lastRowIdx + 1;
+          }
+
+          if ('rowRemovedAt' in update && lastRowIdx >= update.rowRemovedAt) {
+            return lastRowIdx - 1;
+          }
+
+          return lastRowIdx;
+        }, originalRowIdx),
+      );
+  }
+}

--- a/libs/table/src/lib/table/table.component.ts
+++ b/libs/table/src/lib/table/table.component.ts
@@ -16,6 +16,7 @@ import {
   SimpleChanges,
   SkipSelf,
   TemplateRef,
+  Type,
   ViewChild,
   ViewContainerRef,
   ViewEncapsulation,
@@ -26,6 +27,7 @@ import {
   EMPTY,
   merge,
   MonoTypeOperatorFunction,
+  Observable,
   of,
   ReplaySubject,
   Subject,
@@ -34,6 +36,7 @@ import {
   catchError,
   delay,
   distinctUntilChanged,
+  filter,
   map,
   mapTo,
   pairwise,
@@ -394,6 +397,26 @@ export class CoreTableComponent
 
   ngOnDestroy(): void {
     this.destroyed$.next();
+  }
+
+  on(feature: string, eventName?: string) {
+    return this.tableEventBus.on(feature, eventName);
+  }
+
+  findFeatureByName(name: string): Observable<TableFeatureComponent> {
+    return this.features$.pipe(
+      map((features) => features.find((feature) => feature.name === name)),
+      filter((feature) => feature !== undefined),
+    ) as Observable<TableFeatureComponent>;
+  }
+
+  findFeatureByType<T extends TableFeatureComponent>(
+    type: Type<T>,
+  ): Observable<T> {
+    return this.features$.pipe(
+      map((features) => features.find((feature) => feature instanceof type)),
+      filter((feature) => feature !== undefined),
+    ) as Observable<T>;
   }
 
   updateRowClasses(rowIdx: string, classes: Record<string, boolean>): void {

--- a/libs/table/src/lib/table/table.ts
+++ b/libs/table/src/lib/table/table.ts
@@ -1,9 +1,10 @@
 /* tslint:disable:no-empty-interface */
+import { ElementRef, Injector, Type } from '@angular/core';
 import { LayoutFlatConfig } from '@orchestrator/layout';
 import { Observable } from 'rxjs';
-import { ElementRef, Injector, Type } from '@angular/core';
-import { TableFeatureConfig } from '../table-config/types';
+
 import { TableActionTriggeredEvent } from '../../lib/table-actions';
+import { TableFeatureConfig } from '../table-config/types';
 import { TableFeatureComponent } from '../table-feature';
 
 export interface TableColumn extends Partial<TableColumnTypeDef> {
@@ -113,6 +114,11 @@ export interface TableComponent {
   tableElementRef: ElementRef<HTMLElement>;
   updateRowClasses(rowIdx: string, classes: Record<string, boolean>): void;
   setRowClasses(rowIdx: string, classes: Record<string, boolean>): void;
+  on(feature: string, eventName?: string): Observable<unknown>;
+  findFeatureByName(name: string): Observable<TableFeatureComponent>;
+  findFeatureByType<T extends TableFeatureComponent>(
+    type: Type<T>,
+  ): Observable<T>;
 }
 
 export enum TableFeatureLocation {

--- a/libs/table/testing/src/test-feature.ts
+++ b/libs/table/testing/src/test-feature.ts
@@ -47,6 +47,9 @@ export class TableMockComponent implements TableComponent {
   updateRowClasses = jest.fn();
   setRowClasses = jest.fn();
   eventHandler = jest.fn();
+  on = jest.fn();
+  findFeatureByName = jest.fn();
+  findFeatureByType = jest.fn();
   tableElementRef = (new MockElementRef() as unknown) as ElementRef<
     HTMLElement
   >;


### PR DESCRIPTION
This is a POC that explores how to use datasource concepts to implement dependable editable table columns.

Basically there is a higher-order "dependable" datasource that watches value of another column and when it's changed - it triggers inner datasource.

Then "dependable" with inner datasource is used on the editable table column that depends on another table column.

_NOTE:_ This approach limits dependable columns to only those who allow values from datasource (like select).
_NOTE 2:_ In this POC proper datasources are not yet implemented so simpler "Table Datasource"s were used for demo purposes.
Once proper datasources are implemented the value of "dependent" column will be available in the context of the inner datasource config (so it's possible to configure URL to use it in the http datasource).

Example of dependable editable column:
https://github.com/spryker/ui-components/blob/927426aa2d34b1c99a66d0408608727df4d437e0/libs/table.column.select/src/lib/table-column-select.component.stories.ts#L175-L188
