### PR TITLE
[POC] Add submitter to the form data 

### DIFF
--- a/libs/ajax-form/src/lib/ajax-form/ajax-form.component.stories.ts
+++ b/libs/ajax-form/src/lib/ajax-form/ajax-form.component.stories.ts
@@ -24,6 +24,7 @@ const mockHtmlTemplate = () => `
   <input type="text" name="name4" style="border: 1px solid red">
   <br>
   <button type="submit">Submit</button>
+  <button type="submit" name="submit2">Submit #2</button>
 `;
 
 function generateMockHtmlPage(): any {

--- a/libs/ajax-form/src/lib/ajax-form/ajax-form.component.ts
+++ b/libs/ajax-form/src/lib/ajax-form/ajax-form.component.ts
@@ -20,6 +20,12 @@ import { AjaxFormRequestToken } from './tokens';
 
 import { AjaxFormResponse } from '../types';
 
+export interface SubmitEvent extends Event {
+  // See https://developer.mozilla.org/en-US/docs/Web/API/SubmitEvent/submitter
+  // See https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-submitevent-submitter
+  submitter: HTMLElement | null;
+}
+
 @Component({
   selector: 'spy-ajax-form',
   templateUrl: './ajax-form.component.html',
@@ -96,10 +102,21 @@ export class AjaxFormComponent implements OnDestroy, OnChanges, OnInit {
     this.submitSubscription?.unsubscribe();
   }
 
-  submitHandler(form: HTMLFormElement, event: Event): void {
+  submitHandler(form: HTMLFormElement, event: SubmitEvent): void {
     event.preventDefault();
 
+    const submitElem = event.submitter;
     const submitForm = new FormData(form);
+
+    if (submitElem) {
+      const submitName = submitElem.getAttribute('name');
+      const submitValue = submitElem.getAttribute('value') ?? '';
+
+      if (submitName) {
+        submitForm.append(submitName, submitValue);
+      }
+    }
+
     this.isLoading = true;
 
     if (this.action) {


### PR DESCRIPTION
Include a submitter name/value pair to the `FormData` if it's present in the `SubmitEvent`.

_NOTE:_ Submitter Event API is not supported in IE11 and Safari (incl. iOS) so that will require a [polyfill](https://gist.github.com/nuxodin/3ae174f2a6a112df3ccad22459237a91).
