### PR TITLE
fix(styles): adjusted colors by updating color variables

### DIFF
--- a/libs/styles/src/lib/themes/default/variables/colors.less
+++ b/libs/styles/src/lib/themes/default/variables/colors.less
@@ -1,14 +1,14 @@
-@green-dark: #179a82;
-@green: #1bbea0;
+@green-dark: #138671;
+@green: #17b497;
 @green-light: #a0e1d5;
-@green-lighter: #f1f8f7;
+@green-lighter: #f2f8f7;
 
 @blue-dark: #2261af;
 @blue: #2480f2;
-@blue-light: #eaf1fa;
+@blue-light: #ebf1f9;
 
 @red-dark: #c72712;
-@red: #ff3b21;
+@red: #f2392e;
 @red-light: #f9d3ce;
 @red-lighter: #f9f2f1;
 
@@ -20,10 +20,10 @@
 @yellow: #fdaf1c;
 @yellow-light: #fffbe6;
 
-@gray-darker: #71747c;
-@gray-dark: #9ea1a7;
+@gray-darker: #71747b;
+@gray-dark: #9ea1a6;
 @gray: #d4d5d7;
-@gray-light: #f1f1f1;
+@gray-light: #efeeee;
 @gray-lighter: #f8f8f8;
 
 @ink: #121212;


### PR DESCRIPTION
Some of the colors that are defined in the [Figma tokens](https://www.figma.com/file/3Pv69U4zT7FJ9sllzSRMyE/BO-Components?node-id=303%3A243) are incorrect, out of date I assume. While FaaS only uses the primary and neutral colors, we've aligned all colors to ensure others won't come into the same issue (i.e. #396 was just merged yesterday).

Update: after merging the next release in, we noticed that some of the colors have already been fixed.
