### PR TITLE
Update @sryker/icons from 0.2.7 to 0.3.0beta

### DIFF
--- a/libs/rating/package.json
+++ b/libs/rating/package.json
@@ -5,7 +5,7 @@
     "@angular/common": "^9.1.12",
     "@angular/core": "^9.1.12",
     "@angular/forms": "^9.1.12",
-    "@spryker/icon": "^0.2.7",
+    "@spryker/icon": "^0.3.0-beta.0",
     "@spryker/styles": "^0.3.2",
     "@spryker/utils": "^0.2.8"
   },


### PR DESCRIPTION
@spryker/rating uses IconStarModule, which is not available in @spryker/icon 0.2.7 and only available in 0.3.0beta
