### PR TITLE
fix(table.feature.sync-state): call `TableDataConfiguratorService.triggerInitialData()` method to save initial data state

### DIFF
--- a/libs/table.feature.sync-state/src/lib/table-sync-state-feature.component.ts
+++ b/libs/table.feature.sync-state/src/lib/table-sync-state-feature.component.ts
@@ -61,6 +61,7 @@ export class TableSyncStateFeatureComponent extends TableFeatureComponent<TableS
         const syncStateInitialData = new SyncStateInitialDataStrategy(urlState$);
 
         service.provideInitialDataStrategy(syncStateInitialData);
+        service.triggerInitialData();
 
         this.configToState$ = combineLatest([this.tableId$, service.config$]).pipe(
             tap(([tableId, config]) => this.urlPersistenceStrategy.save(tableId, config)),


### PR DESCRIPTION
Ticket: https://spryker.atlassian.net/browse/CC-25964